### PR TITLE
NVDA add-on: slightly widened range of excitation parameter

### DIFF
--- a/nvda/synthDrivers/bestspeech.py
+++ b/nvda/synthDrivers/bestspeech.py
@@ -164,13 +164,13 @@ class SynthDriver(SynthDriver):
 
 	def _set_excitation(self, vl):
 		n = int(vl)
-		self._excitation = vl if n > -1 and n < 7 else 1
+		self._excitation = vl if n > -1 and n < 8 else 1
 
 	def _get_excitation(self):
 		return self._excitation
 
 	def _get_availableExcitations(self):
-		return { str(i): StringParameterInfo(str(i), str(i)) for i in range(7)}
+		return { str(i): StringParameterInfo(str(i), str(i)) for i in range(8)}
 
 	def _set_numberProcessing(self, val):
 		self._numberProcessing = bool(val)


### PR DESCRIPTION
This PR widens the excitation parameter range from 6 to 7, enabling access to another excitation setting in the engine. Technically the ~e option in the Windows DLL goes from 1 to 10, but since excitations 8, 9 and 10 aren't very intelligible, I wasn't sure if those should be made accessible or not.